### PR TITLE
Support for battery level

### DIFF
--- a/lib/Switchmate3Device.js
+++ b/lib/Switchmate3Device.js
@@ -17,6 +17,7 @@ var Switchmate3Device = function (sm_peripheral)
     NobleDevice.call(self, sm_peripheral);
     EventEmitter.call(self);
     self.ToggleState = null;
+    self.BatteryLevel = null;
     if (sm_peripheral.advertisement.manufacturerData && sm_peripheral.advertisement.manufacturerData.length === 6)
     {
         self.ToggleState = Boolean(sm_peripheral.advertisement.manufacturerData[0] & 0x01 === 1);
@@ -89,6 +90,7 @@ Switchmate3Device.SCAN_DUPLICATES = true;
 // inherit noble device
 util.inherits(Switchmate3Device, EventEmitter);
 NobleDevice.Util.inherits(Switchmate3Device, NobleDevice);
+NobleDevice.Util.mixin(Switchmate3Device, NobleDevice.BatteryService);
 
 Switchmate3Device.prototype.isOn = function (done)
 {
@@ -129,6 +131,24 @@ Switchmate3Device.prototype.notifyToggleResult = function (callback)
 {
     this.onToggleResultBinded = this.onToggleResult.bind(this);
     this.notifyCharacteristic(SM_SERVICE_UUID, SM_STATUS_CHAR, true, this.onToggleResultBinded, callback);
+};
+
+Switchmate3Device.prototype.onBatteryLevelResult = function (error, data)
+{
+    if (!error) {
+        this.BatteryLevel = parseInt(data);
+        this.emit('batteryLevelResponse', this.BatteryLevel);
+    } else
+    {
+        this.emit('batteryLevelFail', error);
+    }
+    this.emit('batteryLevelDone');
+};
+
+Switchmate3Device.prototype.readBatteryLevelResult = function ()
+{
+    this.onBatteryLevelResultBinded = this.onBatteryLevelResult.bind(this);
+    this.readBatteryLevel(this.onBatteryLevelResultBinded);
 };
 
 Switchmate3Device.prototype.startPollingSwitchmate3 = function ()

--- a/lib/Switchmate3ToggleSession.js
+++ b/lib/Switchmate3ToggleSession.js
@@ -26,9 +26,9 @@ var Switchmate3ToggleSession = function (sm_device)
         clearTimeout(self._connectTimeout);
         self.connectAttempts += 1;
         self.event.emit('msg', 'Connected to Switchmate3 ' + self.Switchmate3.id + '.');
+        self.Switchmate3.readBatteryLevelResult();
         self.Switchmate3.notifyToggleResult(function (err)
         {
-
             if (!err)
             {
                 self.doToggle();


### PR DESCRIPTION
This adds support for reading the battery level of the Switchmate.

Reading the battery level requires an active Bluetooth connection (unless it's hidden in the manufacturer data somewhere, but I couldn't find it), so to make this efficient and not open a connection more than needed, the battery level is read at the same time a toggle action completes and cached for future use. If a toggle action has not been run from this library, the battery level will not be populated.